### PR TITLE
Add cors configuration to apollo server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import connectRedis from "connect-redis";
 // let RedisStore = require("connect-redis")(session);
 
 import { MyContext } from "./types";
-import cors from "cors";
 
 const main = async () => {
   // DB Setup
@@ -25,13 +24,11 @@ const main = async () => {
   await orm.getMigrator().up(); // run migrations
   // Server Setup
   const app = express();
+  const corsOptions = {
+    credentials: true,
+    origin: "https://studio.apollographql.com",
+  };
   app.set("trust proxy", !__prod__);
-  app.use(
-    cors({
-      credentials: true,
-      origin: ["http://localhost:4000", "https://studio.apollographql.com"],
-    })
-  );
 
   // Redis Setup
   const RedisStore = connectRedis(session);
@@ -67,7 +64,7 @@ const main = async () => {
 
   // Start-up Servers
   await apolloServer.start();
-  apolloServer.applyMiddleware({ app });
+  apolloServer.applyMiddleware({ app, cors: corsOptions });
 
   app.listen(4000, () => {
     console.log("server started on localhost:4000");

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -13,7 +13,7 @@ export default {
   dbName: "thewizard",
   user: "postgres",
   password: "postgres",
-  host: "127.0.0.1",
+  host: "172.18.96.1",
   port: 5432,
   type: "postgresql",
   debug: !__prod__,

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -7,6 +7,7 @@ import {
   InputType,
   Mutation,
   ObjectType,
+  Query,
   Resolver,
 } from "type-graphql";
 import argon2 from "argon2";
@@ -40,10 +41,19 @@ class UserResponse {
 
 @Resolver()
 export class UserResolver {
+  @Query(() => User, { nullable: true })
+  async me(@Ctx() { req, em }: MyContext) {
+    if (!req.session.userId) {
+      return null;
+    }
+    const user = await em.findOne(User, { id: req.session.userId });
+    return user;
+  }
+
   @Mutation(() => UserResponse)
   async register(
     @Arg("options") options: UsernamePasswordInput,
-    @Ctx() { em }: MyContext
+    @Ctx() { em, req }: MyContext
   ): Promise<UserResponse> {
     if (options.username.length <= 2) {
       return {
@@ -88,6 +98,10 @@ export class UserResolver {
       }
       console.log("message: ", error.message);
     }
+
+    // This will store user id session once they register
+    req.headers["x-forwarded-proto"] = "https";
+    req.session.userId = user.id;
 
     return { user };
   }


### PR DESCRIPTION
Added the cors configuration to the apollo server instead of with express. It was needed in order to use cookies in the GraphQL sandbox. Now cookies work seamlessly in the sandbox. 

Also created a Me Query just to identify who is currently logged in.

Now when registering, a user's ID is stored in the session (logged in)